### PR TITLE
API Bump

### DIFF
--- a/LazyAlchemyLearner.lua
+++ b/LazyAlchemyLearner.lua
@@ -210,7 +210,8 @@ local function alchemyQueuer(combos)
 	local solvent
 	local position = 1
 	local queued = 0
-	
+	-- Clear queue in case there's any already queued
+	LLC:cancelItem(CRAFTING_TYPE_ALCHEMY)
 	--I am adding a solvent check here to see if the player has any solvent at all, no need to process anything if nothing will be queued anyway
 	remainingSolvent, solvent, position = getSolvent(GetNonCombatBonus(NON_COMBAT_BONUS_ALCHEMY_LEVEL), position)
 	
@@ -349,6 +350,12 @@ local function genericSlashCommand(args)
 	local searchResult = { string.match(args,"^(%S*)%s*(.-)$") }
 	if searchResult[1] == 'alchemy' then
 		queueLearningAlchemy(searchResult[2] == 'all')
+		if searchResult[2] == 'all' then
+			d("DLC + Base game alchemy traits queued")
+		else
+			d("Base game alchemy traits queued. Type /lazylearn all to also learn DLC traits")
+		end
+		
 	elseif searchResult[1] == 'enchant' then
 		queueLearningEnchanting(searchResult[2] == 'all')
 	elseif searchResult[1] == 'both' then
@@ -369,5 +376,10 @@ SLASH_COMMANDS['/lazylearn'] = genericSlashCommand
 SLASH_COMMANDS["/learnalchemytraits"] = function(arg)
     -- Call the queueLearningAlchemy function with the parsed argument
     queueLearningAlchemy(arg == "all")
+    if arg == 'all' then
+		d("DLC + Base game alchemy traits queued")
+	else
+		d("Base game alchemy traits queued. Type /lazylearn all to also learn DLC traits")
+	end
 end
 -- SLASH_COMMANDS["/learnenchantrunes"] = queueLearningAlchemy

--- a/LazyAlchemyLearner.lua
+++ b/LazyAlchemyLearner.lua
@@ -362,7 +362,7 @@ local function genericSlashCommand(args)
 		if searchResult[2] == 'all' then
 			d("DLC + Base game alchemy traits queued")
 		else
-			d("Base game alchemy traits queued. Type /lazylearn all to also learn DLC traits")
+			d("Base game alchemy traits queued. Type /lazylearn alchemy all to also learn DLC traits")
 		end
 		
 	elseif searchResult[1] == 'enchant' then
@@ -388,7 +388,7 @@ SLASH_COMMANDS["/learnalchemytraits"] = function(arg)
     if arg == 'all' then
 		d("DLC + Base game alchemy traits queued")
 	else
-		d("Base game alchemy traits queued. Type /lazylearn all to also learn DLC traits")
+		d("Base game alchemy traits queued. Type /learnalchemytraits all to also learn DLC traits")
 	end
 end
 -- SLASH_COMMANDS["/learnenchantrunes"] = queueLearningAlchemy

--- a/LazyAlchemyLearner.txt
+++ b/LazyAlchemyLearner.txt
@@ -1,8 +1,8 @@
-﻿## APIVersion: 101043
-## Title: Lazy Alchemy Learner v1.0.5
+﻿## APIVersion: 101044 101045
+## Title: Lazy Alchemy Learner v1.0.6
 ## Description: Learn alchemy traits quick
 ## DependsOn: LibLazyCrafting
-## Version: 1.0.5
+## Version: 1.0.6
 ## Author: Dolgubon, Mathinator
 
 LazyAlchemyLearner.lua


### PR DESCRIPTION
Clear the queue prior to queuing any new items. If user has already queued something, this will prevent double crafting potions Added some output to inform users of the ability to learn DLC traits
Also reworked the 'not enough' messages
- Will not only tell the user once that they are missing a specific reagent
- Will now use the item link when telling them that
- Moved the output of missing materials to the end, to make it a little easier to output